### PR TITLE
exclude cvmfs.autofs on older platforms

### DIFF
--- a/packaging/redhat/cvmfs-setup-autofs.spec
+++ b/packaging/redhat/cvmfs-setup-autofs.spec
@@ -53,6 +53,8 @@ fi
 %if 0%{?fedora} >= 15 || 0%{?rhel} >= 7
 %dir %{_sysconfdir}/auto.master.d
 %{_sysconfdir}/auto.master.d/cvmfs.autofs
+%else
+%exclude %{_sysconfdir}/auto.master.d/cvmfs.autofs
 %endif
 
 %changelog


### PR DESCRIPTION
Without this change packaging fails on RHEL6 with:

```
Checking for unpackaged file(s): /usr/lib/rpm/check-files /root/rpmbuild/BUILDROOT/cvmfs-setup-autofs-1.0-0.el6.x86_64
error: Installed (but unpackaged) file(s) found:
   /etc/auto.master.d/cvmfs.autofs


RPM build errors:
    Installed (but unpackaged) file(s) found:
   /etc/auto.master.d/cvmfs.autofs
```